### PR TITLE
fix(prisma): binaryTargets para Vercel + homepage menú inicial + navb…

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,10 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  outputFileTracingIncludes: {
+    // Incluir el engine de Prisma (path no estándar) en el bundle de Vercel
+    "/api/**": ["./src/generated/prisma/**/*"],
+  },
 };
 
 export default nextConfig;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,6 +1,7 @@
 generator client {
-  provider = "prisma-client"
-  output   = "../src/generated/prisma"
+  provider      = "prisma-client-js"
+  output        = "../src/generated/prisma"
+  binaryTargets = ["native", "rhel-openssl-3.0.x"]
 }
 
 datasource db {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,13 +3,23 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { useSession, signOut } from "next-auth/react";
-import Link from "next/link";
+import {
+  Warning,
+  SignOut,
+  ClockCounterClockwise,
+  Notepad,
+  Gear,
+  ArrowRight,
+  ArrowLeft,
+} from "@phosphor-icons/react";
 import { TURNOS, SUPERVISORES } from "@/lib/constants";
-import { Warning, SignOut, ClockCounterClockwise } from "@phosphor-icons/react";
+
+type View = "menu" | "nuevo-reporte";
 
 export default function HomePage() {
   const router = useRouter();
   const { data: session } = useSession();
+  const [view, setView] = useState<View>("menu");
   const [supervisor, setSupervisor] = useState("");
   const [turno, setTurno] = useState("TURNO MAÑANA");
   const [error, setError] = useState(false);
@@ -31,7 +41,6 @@ export default function HomePage() {
 
       {/* Left — Dark branded panel */}
       <div className="hidden lg:flex flex-col justify-between bg-zinc-950 p-12 relative overflow-hidden">
-        {/* Decorative watermark */}
         <div
           className="absolute -bottom-6 -left-2 text-[13rem] font-black tracking-tighter leading-none text-zinc-900 select-none pointer-events-none"
           aria-hidden="true"
@@ -39,7 +48,6 @@ export default function HomePage() {
           FDT
         </div>
 
-        {/* Top content */}
         <div className="relative z-10">
           <div className="flex items-center gap-2 mb-16">
             <span className="w-2 h-2 rounded-full bg-[#ea580c]" />
@@ -57,7 +65,6 @@ export default function HomePage() {
           </p>
         </div>
 
-        {/* Bottom — user session */}
         {session?.user && (
           <div className="relative z-10 border-t border-zinc-800 pt-5">
             <p className="text-zinc-500 text-xs">{session.user.email}</p>
@@ -73,7 +80,7 @@ export default function HomePage() {
         )}
       </div>
 
-      {/* Right — Form panel */}
+      {/* Right — Content panel */}
       <div className="flex flex-col justify-center px-6 py-12 lg:px-16 lg:py-20 bg-zinc-50">
 
         {/* Mobile branding */}
@@ -103,79 +110,153 @@ export default function HomePage() {
           </div>
         )}
 
-        <div className="w-full max-w-sm">
-          <p className="text-[11px] font-semibold text-zinc-400 tracking-[0.18em] uppercase mb-8">
-            Nuevo reporte
-          </p>
+        {/* ── MENU VIEW ── */}
+        {view === "menu" && (
+          <div className="w-full max-w-sm">
+            <p className="text-[11px] font-semibold text-zinc-400 tracking-[0.18em] uppercase mb-8">
+              ¿Qué querés hacer?
+            </p>
 
-          {/* Supervisor */}
-          <div className="mb-5">
-            <label className="block text-[11px] font-semibold text-zinc-500 uppercase tracking-[0.1em] mb-1.5">
-              Supervisor
-            </label>
-            <select
-              value={supervisor}
-              onChange={(e) => {
-                setSupervisor(e.target.value);
-                if (e.target.value) setError(false);
-              }}
+            {/* Primary: Reporte */}
+            <button
+              onClick={() => setView("nuevo-reporte")}
+              className="group w-full flex items-center justify-between px-6 py-5 bg-[#ea580c] text-white rounded-lg hover:bg-[#c2410c] active:scale-[0.99] active:translate-y-[1px] mb-3"
+              style={{ transition: "all 0.2s var(--ease-spring)" }}
             >
-              <option value="">Seleccionar...</option>
-              {SUPERVISORES.map((s) => (
-                <option key={s} value={s}>
-                  {s}
-                </option>
-              ))}
-            </select>
-            {error && (
-              <p className="flex items-center gap-1.5 text-red-500 text-xs mt-1.5">
-                <Warning size={11} weight="bold" />
-                Seleccioná un supervisor para continuar
-              </p>
-            )}
-          </div>
+              <div className="flex items-center gap-3">
+                <Notepad size={20} weight="duotone" />
+                <div className="text-left">
+                  <p className="font-semibold text-sm leading-tight">Reporte</p>
+                  <p className="text-orange-200 text-xs mt-0.5 font-light">
+                    Nuevo reporte de turno
+                  </p>
+                </div>
+              </div>
+              <ArrowRight
+                size={16}
+                className="opacity-60 group-hover:opacity-100 group-hover:translate-x-0.5"
+                style={{ transition: "all 0.2s var(--ease-spring)" }}
+              />
+            </button>
 
-          {/* Turno */}
-          <div className="mb-8">
-            <label className="block text-[11px] font-semibold text-zinc-500 uppercase tracking-[0.1em] mb-1.5">
-              Turno
-            </label>
-            <div className="grid grid-cols-3 gap-2">
-              {TURNOS.map((t) => (
-                <button
-                  key={t}
-                  type="button"
-                  onClick={() => setTurno(t)}
-                  className={`py-2.5 text-[13px] font-medium rounded-md border active:scale-[0.97] active:translate-y-[1px] ${
-                    turno === t
-                      ? "bg-[#ea580c] border-[#ea580c] text-white"
-                      : "bg-white border-zinc-200 text-zinc-600 hover:border-zinc-400 hover:text-zinc-800"
-                  }`}
-                  style={{ transition: "all 0.2s var(--ease-spring)" }}
-                >
-                  {t.replace("TURNO ", "")}
-                </button>
-              ))}
+            {/* Secondary: Historial */}
+            <button
+              onClick={() => router.push("/historial")}
+              className="group w-full flex items-center justify-between px-6 py-4 bg-white border border-zinc-200 text-zinc-700 rounded-lg hover:border-zinc-400 hover:text-zinc-900 active:scale-[0.99] active:translate-y-[1px] mb-2"
+              style={{ transition: "all 0.2s var(--ease-spring)" }}
+            >
+              <div className="flex items-center gap-3">
+                <ClockCounterClockwise size={17} className="text-zinc-400 group-hover:text-zinc-600" style={{ transition: "color 0.2s var(--ease-spring)" }} />
+                <div className="text-left">
+                  <p className="font-medium text-sm leading-tight">Historial</p>
+                  <p className="text-zinc-400 text-xs mt-0.5 font-light">
+                    Reportes anteriores
+                  </p>
+                </div>
+              </div>
+              <ArrowRight
+                size={14}
+                className="text-zinc-300 group-hover:text-zinc-500 group-hover:translate-x-0.5"
+                style={{ transition: "all 0.2s var(--ease-spring)" }}
+              />
+            </button>
+
+            {/* Secondary: Configuración */}
+            <button
+              onClick={() => router.push("/configuracion")}
+              className="group w-full flex items-center justify-between px-6 py-4 bg-white border border-zinc-200 text-zinc-700 rounded-lg hover:border-zinc-400 hover:text-zinc-900 active:scale-[0.99] active:translate-y-[1px]"
+              style={{ transition: "all 0.2s var(--ease-spring)" }}
+            >
+              <div className="flex items-center gap-3">
+                <Gear size={17} className="text-zinc-400 group-hover:text-zinc-600" style={{ transition: "color 0.2s var(--ease-spring)" }} />
+                <div className="text-left">
+                  <p className="font-medium text-sm leading-tight">Configuración</p>
+                  <p className="text-zinc-400 text-xs mt-0.5 font-light">
+                    SMTP, destinatarios, ajustes
+                  </p>
+                </div>
+              </div>
+              <ArrowRight
+                size={14}
+                className="text-zinc-300 group-hover:text-zinc-500 group-hover:translate-x-0.5"
+                style={{ transition: "all 0.2s var(--ease-spring)" }}
+              />
+            </button>
+          </div>
+        )}
+
+        {/* ── NUEVO REPORTE VIEW ── */}
+        {view === "nuevo-reporte" && (
+          <div className="w-full max-w-sm">
+            <button
+              onClick={() => { setView("menu"); setError(false); }}
+              className="flex items-center gap-1.5 text-[11px] font-semibold text-zinc-400 tracking-[0.18em] uppercase mb-8 hover:text-zinc-600"
+              style={{ transition: "color 0.2s var(--ease-spring)" }}
+            >
+              <ArrowLeft size={11} weight="bold" />
+              Nuevo reporte
+            </button>
+
+            {/* Supervisor */}
+            <div className="mb-5">
+              <label className="block text-[11px] font-semibold text-zinc-500 uppercase tracking-[0.1em] mb-1.5">
+                Supervisor
+              </label>
+              <select
+                value={supervisor}
+                onChange={(e) => {
+                  setSupervisor(e.target.value);
+                  if (e.target.value) setError(false);
+                }}
+              >
+                <option value="">Seleccionar...</option>
+                {SUPERVISORES.map((s) => (
+                  <option key={s} value={s}>
+                    {s}
+                  </option>
+                ))}
+              </select>
+              {error && (
+                <p className="flex items-center gap-1.5 text-red-500 text-xs mt-1.5">
+                  <Warning size={11} weight="bold" />
+                  Seleccioná un supervisor para continuar
+                </p>
+              )}
             </div>
+
+            {/* Turno */}
+            <div className="mb-8">
+              <label className="block text-[11px] font-semibold text-zinc-500 uppercase tracking-[0.1em] mb-1.5">
+                Turno
+              </label>
+              <div className="grid grid-cols-3 gap-2">
+                {TURNOS.map((t) => (
+                  <button
+                    key={t}
+                    type="button"
+                    onClick={() => setTurno(t)}
+                    className={`py-2.5 text-[13px] font-medium rounded-md border active:scale-[0.97] active:translate-y-[1px] ${
+                      turno === t
+                        ? "bg-[#ea580c] border-[#ea580c] text-white"
+                        : "bg-white border-zinc-200 text-zinc-600 hover:border-zinc-400 hover:text-zinc-800"
+                    }`}
+                    style={{ transition: "all 0.2s var(--ease-spring)" }}
+                  >
+                    {t.replace("TURNO ", "")}
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            <button
+              onClick={handleStart}
+              className="w-full py-3 px-6 bg-[#ea580c] text-white font-medium text-sm rounded-md hover:bg-[#c2410c] active:scale-[0.99] active:translate-y-[1px]"
+              style={{ transition: "all 0.2s var(--ease-spring)" }}
+            >
+              Iniciar Reporte
+            </button>
           </div>
-
-          <button
-            onClick={handleStart}
-            className="w-full py-3 px-6 bg-[#ea580c] text-white font-medium text-sm rounded-md hover:bg-[#c2410c] active:scale-[0.99] active:translate-y-[1px]"
-            style={{ transition: "all 0.2s var(--ease-spring)" }}
-          >
-            Iniciar Reporte
-          </button>
-
-          <Link
-            href="/historial"
-            className="flex items-center justify-center gap-2 w-full py-2.5 px-6 text-zinc-500 text-sm rounded-md border border-zinc-200 hover:border-zinc-400 hover:text-zinc-700 mt-3"
-            style={{ transition: "all 0.2s var(--ease-spring)" }}
-          >
-            <ClockCounterClockwise size={14} />
-            Ver historial
-          </Link>
-        </div>
+        )}
       </div>
     </div>
   );

--- a/src/components/fdt-form/FDTFormWrapper.tsx
+++ b/src/components/fdt-form/FDTFormWrapper.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback, useMemo } from "react";
+import { useRouter } from "next/navigation";
 import { useForm, FormProvider, type FieldErrors } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import {
@@ -29,6 +30,7 @@ import {
   ChatText,
   Users,
   Gear,
+  House,
   Database,
   Sliders,
   Thermometer,
@@ -143,9 +145,11 @@ function getErrorAtPath(
 }
 
 export function FDTFormWrapper({ settings }: { settings: AppSettings }) {
+  const router = useRouter();
   const [activeTab, setActiveTab] = useState("encabezado");
   const [viewMode, setViewMode] = useState<"panel" | "form">("panel");
   const [clearConfirm, setClearConfirm] = useState(false);
+  const [homeConfirm, setHomeConfirm] = useState(false);
   const [draftSavedAt, setDraftSavedAt] = useState<Date | null>(null);
   const [emitState, setEmitState] = useState<EmitState>("idle");
   const [emitError, setEmitError] = useState<string | null>(null);
@@ -452,25 +456,38 @@ export function FDTFormWrapper({ settings }: { settings: AppSettings }) {
             </button>
           )}
 
-          {/* Historial */}
-          <a
-            href="/historial"
-            className="flex items-center gap-1.5 px-2.5 py-1.5 text-xs font-medium text-zinc-400 hover:text-white rounded border border-zinc-800 hover:border-zinc-600"
-            style={{ transition: "all 0.15s var(--ease-spring)" }}
-          >
-            <ClockCounterClockwise size={12} />
-            <span className="hidden sm:inline">Historial</span>
-          </a>
-
-          {/* Configuración */}
-          <a
-            href="/configuracion"
-            className="p-1.5 text-zinc-600 hover:text-zinc-300 rounded"
-            title="Configuración"
-            style={{ transition: "color 0.15s var(--ease-spring)" }}
-          >
-            <Gear size={14} />
-          </a>
+          {/* Home — con confirmación */}
+          {homeConfirm ? (
+            <div className="flex items-center gap-2">
+              <span className="text-xs text-zinc-400">¿Volver al menú?</span>
+              <button
+                type="button"
+                onClick={() => router.push("/")}
+                className="text-xs text-white font-medium hover:text-zinc-300"
+                style={{ transition: "color 0.15s var(--ease-spring)" }}
+              >
+                Sí
+              </button>
+              <button
+                type="button"
+                onClick={() => setHomeConfirm(false)}
+                className="text-xs text-zinc-600 hover:text-zinc-400"
+                style={{ transition: "color 0.15s var(--ease-spring)" }}
+              >
+                Cancelar
+              </button>
+            </div>
+          ) : (
+            <button
+              type="button"
+              onClick={() => setHomeConfirm(true)}
+              className="p-1.5 text-zinc-600 hover:text-zinc-300 rounded"
+              title="Volver al menú inicial"
+              style={{ transition: "color 0.15s var(--ease-spring)" }}
+            >
+              <House size={14} />
+            </button>
+          )}
 
           {/* Clear draft (not in emitted state) */}
           {!isEmitted &&


### PR DESCRIPTION
…ar home

- prisma/schema.prisma: agrega binaryTargets ["native", "rhel-openssl-3.0.x"] y cambia provider a prisma-client-js para incluir engine Linux en deploy
- next.config.ts: outputFileTracingIncludes para que Vercel empaquete el engine de Prisma desde el output path no estándar (src/generated/prisma/)
- src/app/page.tsx: rediseño como menú inicial con botón primario Reporte y dos secundarios Historial/Configuración; selector supervisor/turno inline
- FDTFormWrapper.tsx: navbar simplificado — botón Home con confirmación "¿Volver al menú?" reemplaza los links Historial y Configuración