### PR TITLE
Add FDT safeguards and history charts

### DIFF
--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,7 +1,7 @@
 import * as dotenv from "dotenv";
 dotenv.config({ path: ".env.local" });
 
-import { PrismaClient } from "../src/generated/prisma/client";
+import { PrismaClient } from "../src/generated/prisma";
 
 const prisma = new PrismaClient();
 

--- a/src/app/historial/components/ProductionCharts.tsx
+++ b/src/app/historial/components/ProductionCharts.tsx
@@ -18,21 +18,32 @@ const TURNO_COLOR: Record<string, string> = {
   "TURNO NOCHE": "#7c3aed",
 };
 
+const TURNO_ASC: Record<string, number> = {
+  "TURNO MAÑANA": 1,
+  "TURNO TARDE": 2,
+  "TURNO NOCHE": 3,
+};
+
 function shortDate(fecha: string) {
   const [, m, d] = fecha.split("-");
   return `${d}/${m}`;
 }
 
 export function ProductionCharts({ reports, objetivoMoldesColados, objetivoRendimientoHora }: Props) {
-  // Sort ascending by fecha for charts
-  const sorted = [...reports].sort((a, b) => a.fecha.localeCompare(b.fecha));
+  const sorted = [...reports].sort((a, b) => {
+    const byDate = a.fecha.localeCompare(b.fecha);
+    if (byDate !== 0) return byDate;
+    return (TURNO_ASC[a.turno] ?? 0) - (TURNO_ASC[b.turno] ?? 0);
+  });
 
   const chartData = sorted.map((r) => ({
-    fecha: shortDate(r.fecha),
+    fecha: `${shortDate(r.fecha)} ${r.turno.replace("TURNO ", "").slice(0, 1)}`,
     fechaFull: r.fecha,
     turno: r.turno.replace("TURNO ", ""),
     moldesColados: r.salaControlMoldesColados,
     rendimiento: r.molino3RendimientoHora,
+    stockArena: r.stockBarroArena,
+    stockRecupero: r.stockBarroRecupero,
     pallets: r.transformacionTotalPallets ?? 0,
     ausentes: r.cantidadAusentes ?? 0,
     fill: TURNO_COLOR[r.turno] ?? "var(--color-ardal)",
@@ -86,6 +97,60 @@ export function ProductionCharts({ reports, objetivoMoldesColados, objetivoRendi
               stroke="var(--color-ardal)"
               strokeWidth={2}
               dot={{ r: 3, fill: "var(--color-ardal)" }}
+            />
+          </LineChart>
+        </ResponsiveContainer>
+      </div>
+
+      {/* Stock barro arena */}
+      <div className="bg-white border border-zinc-200 rounded-md p-4">
+        <p className="text-[11px] font-semibold text-zinc-500 uppercase tracking-[0.08em] mb-4">
+          Stock Barro Arena en el Tiempo (MT)
+        </p>
+        <ResponsiveContainer width="100%" height={200}>
+          <LineChart data={chartData} margin={{ top: 4, right: 8, left: -16, bottom: 4 }}>
+            <CartesianGrid strokeDasharray="3 3" stroke="#f4f4f5" />
+            <XAxis dataKey="fecha" tick={{ fontSize: 10, fill: "#71717a" }} />
+            <YAxis tick={{ fontSize: 10, fill: "#71717a" }} />
+            <Tooltip
+              contentStyle={{ fontSize: 11, borderRadius: 6, border: "1px solid #e4e4e7" }}
+              labelStyle={{ fontWeight: 600, color: "#18181b" }}
+            />
+            <Legend wrapperStyle={{ fontSize: 11 }} />
+            <Line
+              type="monotone"
+              dataKey="stockArena"
+              name="Arena MT"
+              stroke="#0f766e"
+              strokeWidth={2}
+              dot={{ r: 3, fill: "#0f766e" }}
+            />
+          </LineChart>
+        </ResponsiveContainer>
+      </div>
+
+      {/* Stock barro recupero */}
+      <div className="bg-white border border-zinc-200 rounded-md p-4">
+        <p className="text-[11px] font-semibold text-zinc-500 uppercase tracking-[0.08em] mb-4">
+          Stock Barro Recupero en el Tiempo (MT)
+        </p>
+        <ResponsiveContainer width="100%" height={200}>
+          <LineChart data={chartData} margin={{ top: 4, right: 8, left: -16, bottom: 4 }}>
+            <CartesianGrid strokeDasharray="3 3" stroke="#f4f4f5" />
+            <XAxis dataKey="fecha" tick={{ fontSize: 10, fill: "#71717a" }} />
+            <YAxis tick={{ fontSize: 10, fill: "#71717a" }} />
+            <Tooltip
+              contentStyle={{ fontSize: 11, borderRadius: 6, border: "1px solid #e4e4e7" }}
+              labelStyle={{ fontWeight: 600, color: "#18181b" }}
+            />
+            <Legend wrapperStyle={{ fontSize: 11 }} />
+            <Line
+              type="monotone"
+              dataKey="stockRecupero"
+              name="Recupero MT"
+              stroke="#ca8a04"
+              strokeWidth={2}
+              dot={{ r: 3, fill: "#ca8a04" }}
             />
           </LineChart>
         </ResponsiveContainer>

--- a/src/app/historial/page.tsx
+++ b/src/app/historial/page.tsx
@@ -3,6 +3,7 @@ import { prisma } from "@/lib/prisma";
 import { redirect } from "next/navigation";
 import { getAppSettings } from "@/lib/settings";
 import { HistorialView } from "./components/HistorialView";
+import type { ReportRow } from "./components/HistorialView";
 
 const LIMIT = 50;
 
@@ -32,6 +33,18 @@ const SELECT = {
   tieneIncidentes: true,
   tieneAccidentes: true,
 } as const;
+
+const TURNO_DESC: Record<string, number> = {
+  "TURNO NOCHE": 3,
+  "TURNO TARDE": 2,
+  "TURNO MAÑANA": 1,
+};
+
+function compareReportsDesc(a: ReportRow, b: ReportRow) {
+  const byDate = b.fecha.localeCompare(a.fecha);
+  if (byDate !== 0) return byDate;
+  return (TURNO_DESC[b.turno] ?? 0) - (TURNO_DESC[a.turno] ?? 0);
+}
 
 export default async function HistorialPage({
   searchParams,
@@ -66,18 +79,19 @@ export default async function HistorialPage({
         }
       : {}),
   };
+  const offset = (page - 1) * LIMIT;
 
-  const [reports, total, settings] = await Promise.all([
+  const [allReports, settings] = await Promise.all([
     prisma.report.findMany({
       where,
-      orderBy: [{ fecha: "desc" }, { turno: "asc" }],
-      skip: (page - 1) * LIMIT,
-      take: LIMIT,
+      orderBy: [{ fecha: "desc" }],
       select: SELECT,
     }),
-    prisma.report.count({ where }),
     getAppSettings(),
   ]);
+  const sortedReports = (allReports as ReportRow[]).sort(compareReportsDesc);
+  const reports = sortedReports.slice(offset, offset + LIMIT);
+  const total = sortedReports.length;
 
   return (
     <HistorialView

--- a/src/components/fdt-form/FDTFormWrapper.tsx
+++ b/src/components/fdt-form/FDTFormWrapper.tsx
@@ -110,6 +110,20 @@ const EMIT_STEPS = [
   "Completado",
 ];
 
+const EMIT_WINDOWS: Record<
+  string,
+  { startHour: number; endHour: number; label: string }
+> = {
+  "TURNO MAÑANA": { startHour: 11, endHour: 15, label: "11:00 a 15:00" },
+  "TURNO TARDE": { startHour: 19, endHour: 23, label: "19:00 a 23:00" },
+  "TURNO NOCHE": { startHour: 3, endHour: 7, label: "03:00 a 07:00" },
+};
+
+type EmitWindowWarning = {
+  expectedWindow: string;
+  currentTime: string;
+};
+
 function hasAnyData(obj: Record<string, unknown>): boolean {
   return Object.values(obj).some((v) => {
     if (Array.isArray(v)) return v.length > 0;
@@ -124,6 +138,49 @@ function hasAnyData(obj: Record<string, unknown>): boolean {
 
 function sleep(ms: number) {
   return new Promise<void>((r) => setTimeout(r, ms));
+}
+
+function parseLocalDate(date: string): Date | null {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(date);
+  if (!match) return null;
+
+  const year = Number(match[1]);
+  const month = Number(match[2]) - 1;
+  const day = Number(match[3]);
+  return new Date(year, month, day);
+}
+
+function formatTime(date: Date) {
+  return date.toLocaleTimeString("es-AR", {
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  });
+}
+
+function getEmitWindowWarning(
+  fecha: string | undefined,
+  turno: string | undefined,
+  now: Date
+): EmitWindowWarning | null {
+  if (!fecha || !turno) return null;
+
+  const window = EMIT_WINDOWS[turno];
+  const reportDate = parseLocalDate(fecha);
+  if (!window || !reportDate) return null;
+
+  const start = new Date(reportDate);
+  start.setHours(window.startHour, 0, 0, 0);
+
+  const end = new Date(reportDate);
+  end.setHours(window.endHour, 0, 0, 0);
+
+  if (now >= start && now <= end) return null;
+
+  return {
+    expectedWindow: `${window.label} del ${fecha}`,
+    currentTime: formatTime(now),
+  };
 }
 
 /** Returns true if react-hook-form has a validation error at the given path */
@@ -355,6 +412,11 @@ export function FDTFormWrapper({ settings }: { settings: AppSettings }) {
     | { fecha?: string; turno?: string; supervisor?: string }
     | undefined;
   const encabezadoFilled = !!(enc?.fecha && enc?.turno && enc?.supervisor);
+  const emitWindowWarning = getEmitWindowWarning(
+    enc?.fecha,
+    enc?.turno,
+    new Date()
+  );
 
   // Calculate incomplete required fields (respects conditional fields)
   const incompleteCount = requiredFieldsMap.reduce((count, section) => {
@@ -1160,6 +1222,25 @@ export function FDTFormWrapper({ settings }: { settings: AppSettings }) {
               </p>
               <p>Para: {settings.emailTo || "no configurado"}</p>
             </div>
+
+            {emitWindowWarning && (
+              <div className="flex gap-2 rounded border border-amber-200 bg-amber-50 px-3 py-2 text-[11px] text-amber-900">
+                <Warning
+                  size={14}
+                  weight="fill"
+                  className="mt-0.5 shrink-0 text-amber-500"
+                />
+                <div className="space-y-0.5">
+                  <p className="font-semibold">Horario fuera de rango</p>
+                  <p>
+                    Este reporte debería emitirse entre{" "}
+                    {emitWindowWarning.expectedWindow}. Hora actual:{" "}
+                    {emitWindowWarning.currentTime}.
+                  </p>
+                  <p>Podés emitirlo igual si corresponde.</p>
+                </div>
+              </div>
+            )}
 
             <p className="text-[11px] text-red-500 flex gap-1.5 items-start">
               <Warning size={11} weight="fill" className="mt-0.5 shrink-0" />

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -1,4 +1,4 @@
-import { PrismaClient } from "@/generated/prisma/client";
+import { PrismaClient } from "@/generated/prisma";
 
 const globalForPrisma = globalThis as unknown as { prisma: PrismaClient };
 

--- a/src/lib/report-metrics.ts
+++ b/src/lib/report-metrics.ts
@@ -1,4 +1,4 @@
-import type { Prisma } from "@/generated/prisma/client";
+import type { Prisma } from "@/generated/prisma";
 import type { Report } from "@/lib/schema";
 
 /**


### PR DESCRIPTION
## Resumen
- Agrega advertencia no bloqueante al emitir un FDT fuera de la ventana horaria del turno.
- Corrige imports de Prisma para usar el entrypoint generado estable y evitar el client viejo de Windows.
- Ordena el historial por fecha descendente y turno NOCHE/TARDE/MAÑANA.
- Agrega gráficos de stock de barro arena y recupero en el historial.

## Validación
- npx prisma generate
- npm run build
- npx eslint src/app/historial/page.tsx src/app/historial/components/ProductionCharts.tsx src/app/historial/components/HistorialView.tsx
- npx eslint src/components/fdt-form/FDTFormWrapper.tsx src/lib/prisma.ts src/lib/report-metrics.ts prisma/seed.ts